### PR TITLE
Add a base/demo deployment of the summary stats app

### DIFF
--- a/gnomad-sumstats/base/deployment.yaml
+++ b/gnomad-sumstats/base/deployment.yaml
@@ -1,0 +1,36 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: gnomad-sumstats
+  labels:
+    service: gnomad-sumstats
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: gnomad-sumstats
+  template:
+    metadata:
+      labels:
+        name: gnomad-sumstats
+    spec:
+      containers:
+        - name: shiny
+          image: gnomad-sumstats
+          ports:
+            - name: http
+              containerPort: 8000
+          resources:
+            requests:
+              cpu: 800m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 30

--- a/gnomad-sumstats/base/kustomization.yaml
+++ b/gnomad-sumstats/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+- service.yaml
+

--- a/gnomad-sumstats/base/service.yaml
+++ b/gnomad-sumstats/base/service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gnomad-sumstats
+  labels:
+    service: gnomad-sumstats
+spec:
+  type: ClusterIP
+  selector:
+    name: gnomad-sumstats
+  ports:
+    - port: 80
+      targetPort: 8000

--- a/gnomad-sumstats/demo/backendconfig.yaml
+++ b/gnomad-sumstats/demo/backendconfig.yaml
@@ -1,0 +1,8 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: gnomad-sumstats-bc
+spec:
+  sessionAffinity:
+    affinityType: 'CLIENT_IP'
+  timeoutSec: 3000 # we apparently need this to avoid terminating websockets

--- a/gnomad-sumstats/demo/ingress.yaml
+++ b/gnomad-sumstats/demo/ingress.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gnomad-sumstats
+  annotations:
+    networking.gke.io/managed-certificates: sumstats-gnomad-cert-demo
+  labels:
+    service: gnomad-sumstats
+spec:
+  rules:
+    - host: 'sumstats.gnomad.the-tgg.dev'
+      http:
+        paths:
+          - backend:
+              service:
+                name: gnomad-sumstats
+                port:
+                  number: 80
+            pathType: ImplementationSpecific

--- a/gnomad-sumstats/demo/kustomization.yaml
+++ b/gnomad-sumstats/demo/kustomization.yaml
@@ -1,0 +1,49 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - ingress.yaml
+  - backendconfig.yaml
+  - managed-certificate.yaml
+nameSuffix: -demo
+labels:
+  - includeSelectors: true
+    includeTemplates: true
+    pairs:
+      environment: qa
+      name: gnomad-sumstats-demo
+images:
+  - name: gnomad-sumstats
+    newName: us-docker.pkg.dev/exac-gnomad/gnomad/gnomad-sumstats-explorer
+    newTag: abcdef1
+patches:
+  - patch: |-
+      kind: Service
+      apiVersion: v1
+      metadata:
+        name: gnomad-sumstats
+        annotations:
+          cloud.google.com/backend-config: '{"default": "gnomad-sumstats-bc-demo"}'
+  - patch: |-
+      kind: Deployment
+      apiVersion: apps/v1
+      metadata:
+        name: gnomad-sumstats
+      spec:
+        template:
+          spec:
+            tolerations:
+              - key: "volatile"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: gnomad-sumstats
+      spec:
+        template:
+          spec:
+            nodeSelector:
+              cloud.google.com/gke-nodepool: 'demo-pool'

--- a/gnomad-sumstats/demo/managed-certificate.yaml
+++ b/gnomad-sumstats/demo/managed-certificate.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: sumstats-gnomad-cert
+spec:
+  domains:
+    - sumstats.gnomad.the-tgg.dev


### PR DESCRIPTION
This adds a base deployment for the summary stats Shiny app, and a demo kustomization for deploying it behind an ingress with a TLS cert for testing purposes.

For prod, it depends on what we're interested in -- I suspect that we'll want to serve this off of the gnomad.broadinstitute.org subdomain, so I imagine the ingress won't be needed for a prod deployment.