### PR TITLE
Use new readviz disk with v4 STR metadata

### DIFF
--- a/reads/base/reads.deployment.yaml
+++ b/reads/base/reads.deployment.yaml
@@ -79,5 +79,5 @@ spec:
         - name: readviz
           gcePersistentDisk:
             fsType: ext4
-            pdName: readviz-data-v4-2023-10-28
+            pdName: readviz-data-v4-2025-03-10
             readOnly: true


### PR DESCRIPTION
This disk has the new metadata for updated (v4) STRs to support the updated code in the browser, but also the old v3 STR data for backwards compatibility with the current production browser. Once the new STR code is running in the production browser, we can delete the v3 data.