### PR TITLE
Update Exome Results Browser production deployment

### DIFF
--- a/exome-results-browsers/base/deployment.yaml
+++ b/exome-results-browsers/base/deployment.yaml
@@ -46,5 +46,5 @@ spec:
         - name: data
           gcePersistentDisk:
             fsType: ext4
-            pdName: exome-results-browsers-data-230123-1052-east1c
+            pdName: exome-results-browsers-data-2025-09-19--15-05
             readOnly: true

--- a/exome-results-browsers/prod/ingress.yaml
+++ b/exome-results-browsers/prod/ingress.yaml
@@ -47,3 +47,12 @@ spec:
                 port:
                   number: 80
             pathType: ImplementationSpecific
+    - host: gp2.broadinstitute.org
+      http:
+        paths:
+          - backend:
+              service:
+                name: exome-results-browsers
+                port:
+                  number: 80
+            pathType: ImplementationSpecific

--- a/exome-results-browsers/prod/kustomization.yaml
+++ b/exome-results-browsers/prod/kustomization.yaml
@@ -13,4 +13,4 @@ labels:
 images:
 - name: exome-results-browsers
   newName: us-docker.pkg.dev/exac-gnomad/gnomad/exome-results-browsers
-  newTag: 92eb84b
+  newTag: 19d5bcb_2025-09-23_gp2-in-production-with-pw


### PR DESCRIPTION
- Include GP2 in production deployment with URL `gp2.broadinstitute...`, for now leave password protected