### PR TITLE
gnomAD-browser: downsize ES cluster to 4 data nodes

### DIFF
--- a/elasticsearch/prod/kustomization.yaml
+++ b/elasticsearch/prod/kustomization.yaml
@@ -105,7 +105,7 @@ patches:
                   - name: install-plugins
                     command: ['sh', '-c', 'bin/elasticsearch-plugin install --batch repository-gcs']
           - name: data-green
-            count: 5
+            count: 4
             config:  # https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
               node.roles: ["data"]
               cluster.routing.allocation.disk.watermark.low: '100gb'


### PR DESCRIPTION
We no longer have both the v4.1.0 (~1.7tb) and v4.1.1 (~2.0tb) variant data living side by side, and many other old unused indices were cleaned up, this freed up ~2.1tb of space on the ES data nodes, letting us remove the 5th ES data node

Previously with the v4.1.1 data alongside the v4.1.0 data we had
- ~7.0tb of indices (or maybe a little more)
- ~8.4tb of space across the 5 nodes
- equaling ~81% usage (7.0 / 8.4)

Now that we've removed the old v4.1.0 data, we only have:
- ~4.9tb of indices
- ~6.8tb of space (if we go from 5 nodes to 4 nodes (8.4 - 1.6 = 6.8))
- usage would be ~71% (4.9 / 6.8)


With the way our Elastic is set up (ECK, since we have an elastic operator as part of the setup) the elastic operator should smartly handle the downsizing of the data, by shuffling the data to the other 4 nodes removing the 5th. Still I'd rather be watching it while it does this, and make a snapshot right before. 

I'm out of office tomorrow (Friday), so will want to do this on Tuesday, May 26th.

---

Total size of all indices on ES is now ~4.9tb:
```
curl -u "elastic:$ELASTICSEARCH_PASSWORD" -X GET "http://localhost:9200/_cluster/stats?human&pretty&filter_path=indices.store.size"
{
  "indices" : {
    "store" : {
      "size" : "4.9tb"
    }
  }
}
```

Each of our 5 data nodes has ~1.6tb of space:
```
curl -u "elastic:$ELASTICSEARCH_PASSWORD" 'http://localhost:9200/_cat/allocation/gnomad-es-data*?v'
shards disk.indices disk.used disk.avail disk.total disk.percent host        ip          node
   135      967.9gb   968.2gb    753.1gb      1.6tb           56 10.164.1.3  10.164.1.3  gnomad-es-data-green-2
   134          1tb       1tb    660.1gb      1.6tb           61 10.164.6.11 10.164.6.11 gnomad-es-data-green-4
   134          1tb       1tb    670.3gb      1.6tb           61 10.164.4.4  10.164.4.4  gnomad-es-data-green-0
   134          1tb       1tb    689.6gb      1.6tb           59 10.164.2.4  10.164.2.4  gnomad-es-data-green-1
   134     1006.6gb  1006.7gb    714.7gb      1.6tb           58 10.164.11.3 10.164.11.3 gnomad-es-data-green-3
```

This equals ~8.4 tb of space currently
```
curl -s -u "elastic:$ELASTICSEARCH_PASSWORD" 'http://localhost:9200/_cat/allocation/gnomad-es-data*?h=disk.total&bytes=b' | awk '{sum += $1} END {printf "%.2f TB\n", sum / 1024 / 1024 / 1024 / 1024}'
8.41 TB
```

If we remove one of the data nodes (1.6tb) that will take us down to 6.8tb of space, for the 4.9tb of indices. 71% usage seems to fall right in the sweet spot.