### PR TITLE
Update Exome Results Browsers production docker image and disk

### DIFF
--- a/exome-results-browsers/base/deployment.yaml
+++ b/exome-results-browsers/base/deployment.yaml
@@ -46,5 +46,5 @@ spec:
         - name: data
           gcePersistentDisk:
             fsType: ext4
-            pdName: erb-data-prod-2026-05-11--19-12
+            pdName: erb-data-prod-2026-06-25--11-53
             readOnly: true

--- a/exome-results-browsers/prod/kustomization.yaml
+++ b/exome-results-browsers/prod/kustomization.yaml
@@ -13,4 +13,4 @@ labels:
 images:
 - name: exome-results-browsers
   newName: us-docker.pkg.dev/exac-gnomad/gnomad/exome-results-browsers
-  newTag: 0fb4b49-prod-2026-06-11--14-16
+  newTag: 0ced661-erb-prod-2026-06-25--14-55


### PR DESCRIPTION
Update to production to include the latest update to the GP2 dataset. New variant data from analyst in the form of more specific case frequency groups, and the addition of the ClinVar dataset/track that is displayed on the single gene pages