### PR TITLE
Update reads image tag for TR data update in gnomAD Browser 

### DIFF
--- a/reads/bluegreen/kustomization.yaml
+++ b/reads/bluegreen/kustomization.yaml
@@ -20,7 +20,7 @@ nameSuffix: -prod
 images:
   - name: gnomad-reads-server
     newName: us-docker.pkg.dev/exac-gnomad/gnomad/gnomad-reads-server
-    newTag: '97f6ac7'
+    newTag: 'd1074c5'
   - name: gnomad-reads-api
     newName: us-docker.pkg.dev/exac-gnomad/gnomad/gnomad-reads-api
-    newTag: '97f6ac7'
+    newTag: 'd1074c5'


### PR DESCRIPTION
This PR is part of the deployment for [a TR data update in the gnomad browser](https://github.com/broadinstitute/gnomad-browser/pull/1923).
