### PR TITLE
Update reads disk for TR data update in gnomAD Browser

### DIFF
--- a/reads/base/reads.deployment.yaml
+++ b/reads/base/reads.deployment.yaml
@@ -79,5 +79,5 @@ spec:
         - name: readviz
           gcePersistentDisk:
             fsType: ext4
-            pdName: readviz-data-v4-2025-03-19
+            pdName: readviz-data-v4-2026-07-30
             readOnly: true


### PR DESCRIPTION
This PR is part of the deployment for https://github.com/broadinstitute/gnomad-browser/pull/1923.

A new STR sqlite db was placed at `../datasets/gnomad_r4_short_tandem_repeats/..` to be used in the above update.
