### PR TITLE
Exome Results Browsers: Create staging environment

### DIFF
--- a/exome-results-browsers/staging/certificate.yaml
+++ b/exome-results-browsers/staging/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: exome-results-browsers-managed-cert
+spec:
+  domains:
+    - asc.the-tgg.dev
+    - bipex.the-tgg.dev
+    - epi25.the-tgg.dev
+    - gp2.the-tgg.dev
+    - ibdseq.the-tgg.dev
+    - schema.the-tgg.dev

--- a/exome-results-browsers/staging/frontendconfig.yaml
+++ b/exome-results-browsers/staging/frontendconfig.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: exome-results-browsers-frontend-config
+spec:
+  redirectToHttps:
+    enabled: true

--- a/exome-results-browsers/staging/ingress.yaml
+++ b/exome-results-browsers/staging/ingress.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: exome-results-browsers-ingress
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: staging-exome-results-browsers-ip
+    networking.gke.io/managed-certificates: staging-exome-results-browsers-managed-cert
+    networking.gke.io/v1beta1.FrontendConfig: staging-exome-results-browsers-frontend-config
+  labels:
+    service: exome-results-browsers
+spec:
+  rules:
+    - host: asc.the-tgg.dev
+      http:
+        paths:
+          - backend:
+              service:
+                name: exome-results-browsers
+                port:
+                  number: 80
+            pathType: ImplementationSpecific
+    - host: bipex.the-tgg.dev
+      http:
+        paths:
+          - backend:
+              service:
+                name: exome-results-browsers
+                port:
+                  number: 80
+            pathType: ImplementationSpecific
+    - host: epi25.the-tgg.dev
+      http:
+        paths:
+          - backend:
+              service:
+                name: exome-results-browsers
+                port:
+                  number: 80
+            pathType: ImplementationSpecific
+    - host: schema.the-tgg.dev
+      http:
+        paths:
+          - backend:
+              service:
+                name: exome-results-browsers
+                port:
+                  number: 80
+            pathType: ImplementationSpecific
+    - host: gp2.the-tgg.dev
+      http:
+        paths:
+          - backend:
+              service:
+                name: exome-results-browsers
+                port:
+                  number: 80
+            pathType: ImplementationSpecific
+    - host: ibdseq.the-tgg.dev
+      http:
+        paths:
+          - backend:
+              service:
+                name: exome-results-browsers
+                port:
+                  number: 80
+            pathType: ImplementationSpecific

--- a/exome-results-browsers/staging/kustomization.yaml
+++ b/exome-results-browsers/staging/kustomization.yaml
@@ -6,6 +6,9 @@ resources:
   - ingress.yaml
   - certificate.yaml
 namePrefix: staging-
+replicas:
+  - name: exome-results-browsers
+    count: 0
 labels:
   - includeSelectors: true
     includeTemplates: true

--- a/exome-results-browsers/staging/kustomization.yaml
+++ b/exome-results-browsers/staging/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - frontendconfig.yaml
+  - ingress.yaml
+  - certificate.yaml
+namePrefix: staging-
+labels:
+  - includeSelectors: true
+    includeTemplates: true
+    pairs:
+      environment: qa
+      name: staging-exome-results-browsers
+images:
+  - name: exome-results-browsers
+    newName: us-docker.pkg.dev/exac-gnomad/gnomad/exome-results-browsers
+    newTag: a21081e-erb-prod-2026-08-14--13-50
+patches:
+  - patch: |-
+      kind: Deployment
+      apiVersion: apps/v1
+      metadata:
+        name: exome-results-browsers
+      spec:
+        template:
+          spec:
+            volumes:
+              - name: data
+                gcePersistentDisk:
+                  pdName: erb-data-prod-2026-08-12--16-29


### PR DESCRIPTION
Creates a staging environment for exome results browsers using our `the-tgg.dev` domain name and subdomains to allow for a staging environment that is nearly identical to production. This lets us check disks with full data, and can allow for multiple password protected demo instances of browsers deployed as part of this single staging environment.

This is currently running, as I `kubectl apply`'d it to make sure things worked.

E.g.:

- https://asc.the-tgg.dev
- https://bipex.the-tgg.dev (this is still the original BipEx, not `BipEx2` as pushing `BipEx2` to production is pending the paper preprint release)
- https://epi25.the-tgg.dev
- https://gp2.the-tgg.dev
- https://ibd.the-tgg.dev
- https://schema.the-tgg.dev (this is `SCHEMA2`, with the new data)

The static IP used for this was manually created with the `gloud` CLI
