### PR TITLE
feat(exome-results-browsers): update production image and disk

### DIFF
--- a/exome-results-browsers/base/deployment.yaml
+++ b/exome-results-browsers/base/deployment.yaml
@@ -46,5 +46,5 @@ spec:
         - name: data
           gcePersistentDisk:
             fsType: ext4
-            pdName: erb-data-prod-2026-07-08--11-31
+            pdName: erb-data-prod-2026-08-12--16-29
             readOnly: true

--- a/exome-results-browsers/prod/kustomization.yaml
+++ b/exome-results-browsers/prod/kustomization.yaml
@@ -13,4 +13,4 @@ labels:
 images:
 - name: exome-results-browsers
   newName: us-docker.pkg.dev/exac-gnomad/gnomad/exome-results-browsers
-  newTag: 538cdaf-prod-2026-07-23--10-46
+  newTag: 4d57257-erb-prod-2026-08-14--14-55


### PR DESCRIPTION
Updates the ERB prod deployment to include updates to the SCHEMA dataset to serve new data, formerly called SCHEMA2, in prod.

https://schema.broadinstitute.org

This is in prod as of Friday, August 15 2026. Just want to merge this PR to have `main` reflect what is currently deployed.

